### PR TITLE
Improve homepage SEO content and structured data

### DIFF
--- a/site/src/components/SEO.astro
+++ b/site/src/components/SEO.astro
@@ -30,6 +30,7 @@ const siteUrl = import.meta.env.PRIMARY_SITE_URL || 'https://platedrop.fit';
 const fullTitle = title?.includes(siteName) ? title : `${title} | ${siteName}`;
 const canonicalURL = canonical || new URL(Astro.url.pathname, siteUrl).href;
 const imageUrl = image?.startsWith('http') ? image : new URL(image, siteUrl).href;
+const imageAlt = `${siteName} - ${title}`;
 
 // JSON-LD structured data
 let jsonLd: any;
@@ -81,6 +82,12 @@ if (structuredData) {
     };
   }
 }
+
+const jsonLdList = Array.isArray(jsonLd)
+  ? jsonLd.filter(Boolean)
+  : jsonLd
+    ? [jsonLd]
+    : [];
 ---
 
 <!-- Primary Meta Tags -->
@@ -95,6 +102,7 @@ if (structuredData) {
 <meta property="og:title" content={fullTitle} />
 <meta property="og:description" content={description} />
 <meta property="og:image" content={imageUrl} />
+<meta property="og:image:alt" content={imageAlt} />
 <meta property="og:site_name" content={siteName} />
 {article && publishedTime && <meta property="article:published_time" content={publishedTime} />}
 {article && modifiedTime && <meta property="article:modified_time" content={modifiedTime} />}
@@ -106,6 +114,7 @@ if (structuredData) {
 <meta name="twitter:title" content={fullTitle} />
 <meta name="twitter:description" content={description} />
 <meta name="twitter:image" content={imageUrl} />
+<meta name="twitter:image:alt" content={imageAlt} />
 
 <!-- Additional Meta Tags -->
 <meta name="robots" content="index, follow" />
@@ -114,4 +123,10 @@ if (structuredData) {
 <meta charset="UTF-8" />
 
 <!-- JSON-LD Structured Data -->
-<script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
+{jsonLdList.map((schema, index) => (
+  <script
+    type="application/ld+json"
+    set:html={JSON.stringify(schema)}
+    key={`structured-data-${index}`}
+  />
+))}

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -182,7 +182,7 @@ const {
   }, observerOptions);
   
   // Observe elements with animation classes
-  document.querySelectorAll('.feature-card, .category-card, .value-prop-card, .deal-wrapper').forEach(el => {
+  document.querySelectorAll('.feature-card, .category-card, .value-prop-card, .deal-wrapper, .faq-item').forEach(el => {
     observer.observe(el);
   });
 </script>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -23,13 +23,50 @@ const formattedDate = displayDate.toLocaleDateString('en-US', {
 });
 
 const itemListSchema = buildItemListSchema(deals);
+const schemaType = deals.length ? 'ItemList' : 'WebPage';
+
+const faqItems = [
+  {
+    question: 'How do you find the best home gym equipment deals?',
+    answer:
+      'Our deal engine checks prices on squat racks, barbells, dumbbells, and cardio machines at major retailers every hour. We only feature discounts that beat the 30 to 90-day average pricing so you see genuine savings.'
+  },
+  {
+    question: 'How often is the PlateDrop home gym deals page updated?',
+    answer:
+      'Fresh data is published daily at 2 AM UTC. When prices change or products go out of stock we remove or refresh them within 24 hours so you are always looking at live offers.'
+  },
+  {
+    question: 'Can beginners use these home gym deals to build a full setup?',
+    answer:
+      'Yes. We highlight foundational gear first—like racks, benches, plates, and adjustable dumbbells—then surface specialty equipment as discounts appear. Pair the deals with our buying guides to build a complete gym on budget.'
+  }
+];
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqItems.map((item) => ({
+    '@type': 'Question',
+    name: item.question,
+    acceptedAnswer: {
+      '@type': 'Answer',
+      text: item.answer
+    }
+  }))
+};
+
+const structuredData = [
+  ...(itemListSchema ? [itemListSchema] : []),
+  faqSchema
+];
 ---
 
 <BaseLayout
   title="Today's Home Gym Deals"
   description="Daily curated deals on home gym equipment including power racks, barbells, dumbbells, and cardio machines. Save on quality fitness gear."
-  schemaType="ItemList"
-  structuredData={itemListSchema}
+  schemaType={schemaType}
+  structuredData={structuredData}
 >
 
   <!-- Hero Section -->
@@ -57,26 +94,27 @@ const itemListSchema = buildItemListSchema(deals);
     <div class="container max-w-[1400px] mx-auto px-6 relative z-10">
       <div class="hero-content max-w-[600px] py-20">
         <h1 class="text-[clamp(2.5rem,6vw,4.5rem)] font-black leading-[1.1] tracking-tight text-white mb-6">
-          Push Your<br/>
-          Limits with Us
+          Today's Best Home Gym Equipment Deals
         </h1>
-        <p class="text-lg leading-relaxed text-white/70 mb-8 max-w-[480px]">
-          Build your dream home gym with curated deals on premium equipment.
-          Verified discounts, updated daily, and expert guidance to help you exceed your fitness goals.
+        <p class="text-lg leading-relaxed text-white/70 mb-6 max-w-[520px]">
+          Discover verified discounts on power racks, barbells, dumbbells, benches, and cardio machines. Our deal experts track prices across trusted retailers so you can build a complete home gym for less.
         </p>
-        
+        <p class="text-sm font-semibold uppercase tracking-[0.2em] text-white/60 mb-10">
+          Updated {formattedDate}
+        </p>
+
         <div class="hero-cta flex items-center gap-4 flex-wrap mb-12">
           <a href="#deals" class="inline-flex items-center gap-2 px-8 py-4 bg-[#ff6b35] text-white text-base font-bold rounded-full no-underline transition-all duration-200 hover:bg-[#ff5722] hover:text-white hover:shadow-lg hover:shadow-[#ff6b35]/30">
-            Join Now
+            See Today's Deals
           </a>
           <button class="inline-flex items-center gap-2 px-6 py-4 bg-transparent text-white text-base font-semibold border-2 border-white/20 rounded-full transition-all duration-200 hover:bg-white/10 hover:border-white/40">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
               <path d="M8 5v14l11-7z"/>
             </svg>
-            Watch Video
+            Watch How PlateDrop Works
           </button>
         </div>
-        
+
         <!-- User Avatars & Stats -->
         <div class="flex items-center gap-6">
           <div class="flex items-center -space-x-3">
@@ -100,6 +138,46 @@ const itemListSchema = buildItemListSchema(deals);
       <span class="px-4 py-2 bg-white/10 backdrop-blur-sm border border-white/20 rounded-full text-white text-xs font-medium">Functional Workouts</span>
     </div>
   </div>
+
+  <!-- SEO Intro Section -->
+  <section class="seo-intro-section py-16 bg-bg text-text">
+    <div class="container max-w-[1100px] mx-auto px-6">
+      <div class="grid gap-12 items-start md:grid-cols-[1.2fr_1fr]">
+        <div class="seo-intro-copy">
+          <h2 class="text-3xl md:text-[2.5rem] font-black tracking-tight mb-6">
+            Why PlateDrop Leads the Home Gym Deal Search Results
+          </h2>
+          <p class="text-base md:text-lg leading-relaxed text-text-secondary mb-6">
+            PlateDrop monitors the same search phrases lifters use—like "best home gym deals," "cheap squat rack," and "adjustable dumbbell sale." Our price history checks filter out fake MSRP discounts so every feature below reflects a real opportunity to save on trusted brands.
+          </p>
+          <p class="text-base md:text-lg leading-relaxed text-text-secondary mb-6">
+            Whether you're piecing together your first garage gym or upgrading with a smart cardio machine, you will find the exact retailer links, specs, and price drops you need. Dive deeper with our in-depth <a href="/guides" class="text-primary font-semibold underline hover:text-secondary">home gym buying guides</a> and <a href="/workouts" class="text-primary font-semibold underline hover:text-secondary">training plans</a> to maximize every piece of equipment you bring home.
+          </p>
+        </div>
+        <div class="seo-intro-sidebar bg-surface border border-border rounded-2xl p-8 shadow-[0_12px_40px_rgba(0,0,0,0.12)]">
+          <h3 class="text-xl font-bold text-text mb-4">Popular Deal Categories</h3>
+          <ul class="space-y-3 text-base text-text-secondary">
+            <li class="flex items-start gap-2">
+              <span class="mt-1 text-primary">•</span>
+              <span>Power racks &amp; squat stands with multi-grip pull-up bars</span>
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="mt-1 text-primary">•</span>
+              <span>Olympic barbells, bumper plates, and quick-change collars</span>
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="mt-1 text-primary">•</span>
+              <span>Adjustable dumbbells, kettlebells, and resistance systems</span>
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="mt-1 text-primary">•</span>
+              <span>Treadmills, rowers, bikes, and connected cardio equipment</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
 
   <!-- Trust Section -->
   <section class="trust-section py-16 bg-bg border-b border-border">
@@ -426,6 +504,37 @@ const itemListSchema = buildItemListSchema(deals);
             Once you have these basics, you can add specialized equipment as deals arise and your training evolves.
           </p>
         </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- FAQ Section -->
+  <section class="faq-section py-24 bg-bg">
+    <div class="container max-w-[1100px] mx-auto px-6">
+      <div class="section-header text-center mb-14">
+        <div class="section-badge inline-flex items-center gap-2 px-5 py-2 bg-gradient-card backdrop-blur-glass border border-glass-border rounded-full text-sm font-bold mb-4">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <circle cx="12" cy="12" r="10"></circle>
+            <path d="M12 16v-4"></path>
+            <circle cx="12" cy="8" r="1"></circle>
+          </svg>
+          <span>Home Gym Deal FAQ</span>
+        </div>
+        <h2 class="section-title text-4xl font-black mb-4 bg-gradient-primary bg-clip-text text-transparent">
+          Answers for Smart Equipment Shoppers
+        </h2>
+        <p class="section-description text-lg text-text-secondary max-w-[65ch] mx-auto">
+          Everything you need to know about tracking gym equipment discounts and choosing the right pieces for your training style.
+        </p>
+      </div>
+
+      <div class="faq-grid space-y-6">
+        {faqItems.map((item, index) => (
+          <div class="faq-item bg-surface border border-border rounded-2xl p-8 shadow-[0_10px_32px_rgba(0,0,0,0.12)] animate-fade-in" style={`animation-delay: ${index * 80}ms`}>
+            <h3 class="text-2xl font-bold text-text mb-3">{item.question}</h3>
+            <p class="text-base text-text-secondary leading-relaxed m-0">{item.answer}</p>
+          </div>
+        ))}
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- expand the homepage hero copy and add a keyword-focused intro section to better target home gym equipment searches
- add an on-page FAQ with supporting schema markup to capture common search queries and rich results
- enhance the SEO component to support multiple JSON-LD blocks and provide image alt metadata for social cards

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68e8145700ec832594111b4659c71a3f